### PR TITLE
fix: fix filter like comparison

### DIFF
--- a/src/utils/convert-filter.ts
+++ b/src/utils/convert-filter.ts
@@ -32,7 +32,7 @@ export const convertFilter = (
       qb.where(path, operators.eq, value as string);
     } else if (property.type() === 'string') {
       // Should be safe: https://github.com/knex/documentation/issues/73#issuecomment-572482153
-      qb.where(raw(`lower("${path}")`), operators.like, `%${String(value).toLowerCase()}%`);
+      qb.where(raw(`lower(${path})`), operators.like, `%${String(value).toLowerCase()}%`);
     } else {
       qb.where(path, operators.eq, value as string);
     }


### PR DESCRIPTION
`lower("${path}")` where path is in `""` will return lowercase string that is provided, not value of column. 