### PR TITLE
fix: fix filter when snakecase mapper is used

### DIFF
--- a/src/utils/convert-filter.ts
+++ b/src/utils/convert-filter.ts
@@ -32,7 +32,7 @@ export const convertFilter = (
       qb.where(path, operators.eq, value as string);
     } else if (property.type() === 'string') {
       // Should be safe: https://github.com/knex/documentation/issues/73#issuecomment-572482153
-      qb.where(raw(`lower(${path})`), operators.like, `%${String(value).toLowerCase()}%`);
+      qb.where(raw('lower(??)', [path]), operators.like, `%${String(value).toLowerCase()}%`);
     } else {
       qb.where(path, operators.eq, value as string);
     }


### PR DESCRIPTION
https://vincit.github.io/objection.js/api/objection/#raw
`You can use ?? as a placeholder for identifiers (column names, aliases etc.) and ? for values.`

fixes filter when [knexSnakeCaseMappers](https://vincit.github.io/objection.js/api/objection/#knexsnakecasemappers) is used + maybe fixes #6 because now it's using params 🤷 